### PR TITLE
ci: add a release pipeline and publish to the Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
+        include:
+          - os: windows
+            extension: ".exe"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Build
+        run: |
+          go build -v -o hue-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.extension }} -ldflags="-X 'main.version=${{ github.event.release.tag_name }}'" .
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+
+      - name: Upload Release Assets
+        uses: SierraSoftworks/gh-releases@v1.0.10
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true
+          files: |
+            hue-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.extension }}
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          desc: Control your Philips Hue lights from your command line

--- a/main.go
+++ b/main.go
@@ -8,9 +8,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// version is overridden at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
 func main() {
 	app := &cli.App{
 		Name:        "hue",
+		Version:     version,
 		Usage:       "Set your light states",
 		Description: "Control your Philips Hue lights from your command line.",
 		Authors: []*cli.Author{


### PR DESCRIPTION
hue had no release workflow. Add one that cross-builds hue-{os}-{arch} for linux/darwin/windows on amd64/arm64, uploads them to the GitHub release, and runs a fan-in tap job (needs build) that updates the hue formula in SierraSoftworks/homebrew-tap via SierraSoftworks/actions-tap.

Also inject the release tag into the binary (-X main.version) so `hue --version` reports it (and the generated formula test passes).