### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ of the day?
 This app is for you, it's a lightweight command line client which lets you
 control your Hue lights with minimal fuss and no extra effort.
 
+## Installation
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/hue
+```
+
 ```powershell
 # Install the latest version of the Hue CLI
 go install github.com/sierrasoftworks/hue@latest


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/hue

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
